### PR TITLE
revise function executed only in dev mode

### DIFF
--- a/commonUtil/executeOnlyInDevMode.js
+++ b/commonUtil/executeOnlyInDevMode.js
@@ -2,7 +2,8 @@ import Constants from 'expo-constants';
 
 export default function executeOnlyInDevMode(func) {
   // 開発ビルドや開発モードではtrueになる
-  if (Constants.manifest.packagerOpts.dev) {
+  // nullとundefinedの場合のみfalse
+  if (Constants.manifest.packagerOpts.dev ?? false) {
     func;
   }
 }


### PR DESCRIPTION
## Added changes
- `Constants.manifest.packagerOpts.dev` returns `undefined` in production mode, so the part is revised to return `false` when it is `null` or `undefined`