### PR TITLE
change versionCode of Android app for the release

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -18,7 +18,7 @@ export default {
   },
   android: {
     package: 'com.tpot.suepapp',
-    versionCode: 16,
+    versionCode: 17,
     permissions: [],
     adaptiveIcon: {
       foregroundImage: './assets/suep_icon.png',


### PR DESCRIPTION
This release is to address an error that occurred because we forgot to change .easignore when we introduced the EAS build.
## Added change
- `versionCode` is raised from 16 to 17 for this release.