### PR TITLE
fix status bar and increase version code for Android build

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -19,7 +19,7 @@ export default {
   },
   android: {
     package: 'com.tpot.suepapp',
-    versionCode: 18,
+    versionCode: 19,
     permissions: [],
     adaptiveIcon: {
       foregroundImage: './assets/suep_icon.png',

--- a/eas.json
+++ b/eas.json
@@ -10,17 +10,17 @@
       "android": {
         "buildType": "apk"
       },
-      "releaseChannel": "dev-x.xx.x"
+      "releaseChannel": "dev-1.1.6.18"
     },
     "preview": {
       "distribution": "internal",
       "android": {
         "buildType": "apk"
       },
-      "releaseChannel": "prev-1.16"
+      "releaseChannel": "prev-1.1.6.18"
     },
     "production": {
-      "releaseChannel": "prod-1.16"
+      "releaseChannel": "prod-1.1.6.18"
     }
   },
   "submit": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "expo": "^46.0.0",
     "expo-application": "~4.2.2",
     "expo-constants": "~13.2.4",
+    "expo-dev-client": "~1.3.1",
     "expo-device": "~4.3.0",
     "expo-splash-screen": "~0.16.2",
     "expo-status-bar": "~1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,6 +3652,42 @@ expo-constants@~13.2.2, expo-constants@~13.2.4:
     "@expo/config" "~7.0.0"
     uuid "^3.3.2"
 
+expo-dev-client@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-1.3.1.tgz#bcaf46bd4646354d8c6fd3b2270d5802d221ac8b"
+  integrity sha512-GGMaLwc3FNdcGB2UsEj252CV9DmWJWMblqX0h5AtiEnmKyVBRn3/yiQyWdPFDkLletYGvDeILfMHUo/PRdOGIA==
+  dependencies:
+    "@expo/config-plugins" "~5.0.0"
+    expo-dev-launcher "1.3.1"
+    expo-dev-menu "1.3.1"
+    expo-dev-menu-interface "0.7.2"
+    expo-manifests "~0.3.0"
+    expo-updates-interface "~0.7.0"
+
+expo-dev-launcher@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-1.3.1.tgz#6e1f117f10443ac26f63a080f0c0c1cd649c9a14"
+  integrity sha512-yZLJZBEnU10suJg1j3HcX2be7ri1qfDek4axbwb4JG5g5T4+wHHvqfTVNlpitg/wfylI8zj2EzZ0jH6A6NtkNQ==
+  dependencies:
+    "@expo/config-plugins" "~5.0.0"
+    expo-dev-menu "1.3.1"
+    resolve-from "^5.0.0"
+    semver "^7.3.5"
+
+expo-dev-menu-interface@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-0.7.2.tgz#2198d014bcbe11335225cc3f100226195b441bc4"
+  integrity sha512-Ym0IFsgBj9bdInjRcxv6xfczdTCKfPKUAsLZ1sD5twpOs7oBViMnTC0+KTGkkYHG4EapWbu9yApPmbV3N10Zcg==
+
+expo-dev-menu@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-1.3.1.tgz#9df51bdc8a29b7f662399a7d678950fc4cbbad46"
+  integrity sha512-D3g4JgmxBl1AFmd4MvZfTjzCBDRBqe/wepcsjOlIPunZ9ad87+ACABgQMi1rQ7S2MzlNk+q9OtntVGXfwfoxMQ==
+  dependencies:
+    "@expo/config-plugins" "~5.0.0"
+    expo-dev-menu-interface "0.7.2"
+    semver "^7.3.5"
+
 expo-device@~4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/expo-device/-/expo-device-4.3.0.tgz#a25257febe8dd18378f556ef61b5ff73ee687a6b"


### PR DESCRIPTION
## Added changes
- Increased version code from `18` to `19`
- Revised the release channels' notations
e.g. `"dev-x.xx.x"` -> `"dev-1.1.6.version code"`