### PR TITLE
revised the url of terms of service page

### DIFF
--- a/screens/otherScreens/TermsOfService.js
+++ b/screens/otherScreens/TermsOfService.js
@@ -6,7 +6,7 @@ export default function TermsOfService() {
   return (
     <WebView
       style={[commonStyles.viewPageContainer, commonStyles.centeredView]}
-      source={{ uri: 'https://suep.netlify.app/post/plivacypolicy/' }}
+      source={{ uri: 'https://suep.netlify.app/post/terms/' }}
     />
   );
 }


### PR DESCRIPTION
## Added changes
- Fixed the url of terms of service page from https://suep.netlify.app/post/plivacypolicy/ to https://suep.netlify.app/post/terms/
Before this commit, the both page displayed the same content